### PR TITLE
update readme for new plugins config structure

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -9,9 +9,7 @@ Simple Usage
     mute: true,
     height: 360,
     width: 640,
-    plugins: { 
-        core: [ClapprSubtitle]
-    },
+    plugins: [ClapprSubtitle],
     subtitle : "video.srt" // URL to subtitle
 });
 player.attachTo(document.getElementById('player'));
@@ -26,9 +24,7 @@ Styling the subtitles
     mute: true,
     height: 360,
     width: 640,
-    plugins: { 
-        core: [ClapprSubtitle]
-    },
+    plugins: [ClapprSubtitle],
     subtitle : {
         src : "video.srt",
         auto : true, // automatically loads subtitle


### PR DESCRIPTION
We changed to a new format in Clappr a while ago where the type of plugin would be automatically detected :)

You are currently using the old way which still works for backwards compatibility but may be removed in the next major release.
